### PR TITLE
Add 2023.06 Beta release notes to .metainfo.xml

### DIFF
--- a/packaging/app.organicmaps.desktop.metainfo.xml
+++ b/packaging/app.organicmaps.desktop.metainfo.xml
@@ -113,6 +113,14 @@
   </screenshots>
 
   <releases>
+   <release version="2023.06.20-1 beta" date="2023-06-20">
+     <description>
+       <p>Highlights:</p>
+         <ul>
+           <li>Ported to Qt6</li>
+         </ul>       
+     </description>
+   </release>
    <release version="2023.06.04-13" date="2023-06-04">
      <description>
        <p>Highlights:</p>


### PR DESCRIPTION
It could be used for beta releases on flatpak-beta channel:
https://github.com/flathub/app.organicmaps.desktop/issues/34